### PR TITLE
Add EditorConfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add [EditorConfig](http://editorconfig.org/) file to avoid formatting headaches when you often switch between projects with different conventions. I set up it with Differential conventions (2 spaces indentation).
