### PR TITLE
Add CoffeeLint configuration.

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,103 @@
+{
+    "arrow_spacing": {
+        "level": "ignore"
+    },
+    "camel_case_classes": {
+        "level": "error"
+    },
+    "coffeescript_error": {
+        "level": "error"
+    },
+    "colon_assignment_spacing": {
+        "level": "ignore",
+        "spacing": {
+            "left": 0,
+            "right": 0
+        }
+    },
+    "cyclomatic_complexity": {
+        "value": 10,
+        "level": "ignore"
+    },
+    "duplicate_key": {
+        "level": "error"
+    },
+    "empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "indentation": {
+        "value": 2,
+        "level": "error"
+    },
+    "line_endings": {
+        "level": "ignore",
+        "value": "unix"
+    },
+    "max_line_length": {
+        "value": 80,
+        "level": "ignore",
+        "limitComments": true
+    },
+    "missing_fat_arrows": {
+        "level": "ignore"
+    },
+    "newlines_after_classes": {
+        "value": 3,
+        "level": "ignore"
+    },
+    "no_backticks": {
+        "level": "error"
+    },
+    "no_debugger": {
+        "level": "warn"
+    },
+    "no_empty_functions": {
+        "level": "ignore"
+    },
+    "no_empty_param_list": {
+        "level": "ignore"
+    },
+    "no_implicit_braces": {
+        "level": "ignore",
+        "strict": true
+    },
+    "no_implicit_parens": {
+        "strict": true,
+        "level": "ignore"
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "ignore"
+    },
+    "no_plusplus": {
+        "level": "ignore"
+    },
+    "no_stand_alone_at": {
+        "level": "ignore"
+    },
+    "no_tabs": {
+        "level": "error"
+    },
+    "no_throwing_strings": {
+        "level": "error"
+    },
+    "no_trailing_semicolons": {
+        "level": "error"
+    },
+    "no_trailing_whitespace": {
+        "level": "error",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": true
+    },
+    "no_unnecessary_double_quotes": {
+        "level": "ignore"
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "non_empty_constructor_needs_parens": {
+        "level": "ignore"
+    },
+    "space_operators": {
+        "level": "ignore"
+    }
+}


### PR DESCRIPTION
[CoffeeLint](http://www.coffeelint.org/) is a powerful tool that checks CoffeeScript syntax and can help debugging code when Meteor is not running. It's like JSHint for CoffeeScript. There are tons of plugins out there to integrate it into your favorite editor. For Vim, [vim-coffee-script](https://github.com/kchmck/vim-coffee-script) supports it built-in. Linters save us from common silly mistakes. It's sometimes a great time saving.

This configuration is the default one with `max_line_length` ignored.
